### PR TITLE
ci: optimize CI workflows and enforce conventional commits

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,10 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    branches: ["main"]
+
+  workflow_dispatch:
 
 jobs:
   lint-and-typecheck:

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -1,0 +1,28 @@
+---
+name: Conventional Commits
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  commit-lint:
+    name: Verify Conventional Commits
+
+    # Skip this job if this is a release or dependabot PR
+    if: (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--') && github.actor != 'dependabot[bot]')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+
+      - name: Check Commit Messages
+        uses: wagoid/commitlint-github-action@v6
+        with: { configFile: .commitlintrc.yml }


### PR DESCRIPTION
This PR improves the GitHub Actions workflows:

## Changes

### Continuous Integration Workflow
- Remove `push` trigger on main branch (reduces duplicate CI runs)
- Keep `pull_request` trigger for PR validation
- Add `workflow_dispatch` for manual CI runs when needed

### Conventional Commits Enforcement
- Add new workflow to enforce conventional commit format on PRs
- Skip enforcement for release-please and dependabot PRs
- Uses existing `.commitlintrc.yml` configuration

## Benefits
- Reduces CI costs by avoiding duplicate runs on main
- Ensures consistent commit message format across the project
- Maintains PR-based validation workflow