### PR TITLE
fix: make Publish Extension job idempotent

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG_NAME="${GITHUB_REF#refs/tags/}"
-          gh release upload "$TAG_NAME" *.vsix
+          gh release upload "$TAG_NAME" *.vsix --clobber
 
       - name: Publish to VS Code Marketplace
         env:


### PR DESCRIPTION
## Overview
This PR makes the Publish Extension GitHub Actions workflow job idempotent so it can be safely rerun if any step fails.

## Changes
- Added `--clobber` flag to the `gh release upload` command in the publish-release workflow
- This allows the VSIX file to be re-uploaded without errors if the job needs to be rerun

## Benefits
- **Improved resilience**: The workflow can now recover from transient failures without manual intervention
- **Safer reruns**: If publishing to VS Code Marketplace or Open VSX fails, the workflow can be rerun without failing on the asset upload step
- **Better developer experience**: No need to manually delete release assets before retrying

## Testing
The `--clobber` flag is a standard option for `gh release upload` that replaces existing assets with the same name.