### PR TITLE
fix: add missing allowed endpoints to publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,10 @@ jobs:
             open-vsx.org:443
             registry.npmjs.org:443
             uploads.github.com:443
+            nodejs.org:443
+            *.githubapp.com:443
+            *.githubusercontent.com:443
+            *.blob.core.windows.net:443
 
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Add missing network endpoints to the `harden-runner` allowed endpoints list in the publish-release workflow.

## Changes
- Added `nodejs.org:443` - Required by npm/vsce for package resolution
- Added `*.githubapp.com:443` - Required for GitHub Actions internal services
- Added `*.githubusercontent.com:443` - Required for downloading release assets
- Added `*.blob.core.windows.net:443` - Required for Azure CDN caching

## Context
These endpoints were blocked during the v0.0.3 release build (see build logs), causing warnings. While the build succeeded, adding these endpoints prevents future issues and removes warnings from the build output.

## Testing
- [ ] Verified against v0.0.3 release build logs
- [ ] All endpoints identified from actual network traffic during publishing