### PR TITLE
docs: fix CI badge to reference correct workflow file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MkDocs Snippet Lens
 
-[![CI](https://github.com/main-branch/mkdocs-snippet-lens/actions/workflows/ci.yml/badge.svg)](https://github.com/main-branch/mkdocs-snippet-lens/actions/workflows/ci.yml)
+[![Continuous Integration](https://github.com/main-branch/mkdocs-snippet-lens/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/main-branch/mkdocs-snippet-lens/actions/workflows/continuous-integration.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Visual Studio Code extension that provides inline previews, clickable links, and


### PR DESCRIPTION
## Summary
Fix the CI badge in README.md to reference the correct GitHub Actions workflow file.

## Changes
- Updated badge label from "CI" to "Continuous Integration" for clarity
- Fixed workflow file reference from `ci.yml` to `continuous-integration.yml`
- Badge now correctly links to the actual workflow runs

## Context
The badge was referencing a non-existent `ci.yml` file, causing it to show an error state. The actual workflow is named `continuous-integration.yml`, so the badge needed to be updated to match.