### PR TITLE
fix: update engines.vscode to match @types/vscode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/main-branch/mkdocs-snippet-lens#readme",
   "engines": {
-    "vscode": "^1.106.1"
+    "vscode": "^1.107.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
## Summary
Fix `vsce package` error by updating `engines.vscode` to match `@types/vscode` version.

## Problem
The "Package extension" step in the Publish Extension job failed with:
```
Error: @types/vscode ^1.107.0 greater than engines.vscode ^1.106.1. 
Either upgrade engines.vscode or use an older @types/vscode version
```

## Solution
Update `engines.vscode` from `^1.106.1` to `^1.107.0` to match the `@types/vscode` version that was updated in PR #8.

## Context
When `@types/vscode` is updated, `engines.vscode` must be updated to match (or be greater) to ensure the extension declares compatibility with the VS Code APIs it's using. This is a requirement enforced by `vsce` during packaging.