### PR TITLE
Update extension display name to 'MkDocs Snippet Lens'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mkdocs-snippet-lens",
-  "displayName": "mkdocs-snippet-lens",
+  "displayName": "MkDocs Snippet Lens",
   "description": "Preview and open MkDocs --8<-- snippets directly in VS Code.",
   "version": "0.0.5",
   "publisher": "main-branch",


### PR DESCRIPTION
This PR updates the extension's display name from "mkdocs-snippet-lens" to "MkDocs Snippet Lens" to improve readability and follow proper capitalization conventions for the extension marketplace.