### PR TITLE
fix: increase timeout for macOS integration tests

### DIFF
--- a/src/test/integration/diagnosticManager.test.ts
+++ b/src/test/integration/diagnosticManager.test.ts
@@ -8,7 +8,17 @@ import * as vscode from 'vscode';
  * correctly creates diagnostics for missing snippet files.
  */
 suite('DiagnosticManager Integration Tests', () => {
-	test('should create diagnostics for missing files', async () => {
+	// Test timing constants for CI environments (especially macOS)
+	const CI_TEST_TIMEOUT = 5000;
+	const EDITOR_ACTIVATION_DELAY = 200;
+	const MAX_DIAGNOSTIC_RETRIES = 20;
+	const RETRY_INTERVAL = 150;
+	const NEGATIVE_TEST_WAIT = 500;
+
+	test('should create diagnostics for missing files', async function() {
+		// Increase timeout for slower CI environments (especially macOS)
+		this.timeout(CI_TEST_TIMEOUT);
+
 		const content = '--8<-- "this-file-does-not-exist.txt"';
 		const doc = await vscode.workspace.openTextDocument({
 			content,
@@ -18,10 +28,13 @@ suite('DiagnosticManager Integration Tests', () => {
 		// Open the document in an editor to trigger diagnostics
 		await vscode.window.showTextDocument(doc);
 
+		// Give the editor a moment to fully activate
+		await new Promise(resolve => setTimeout(resolve, EDITOR_ACTIVATION_DELAY));
+
 		// Wait for diagnostics to be processed with retry logic
 		let snippetDiagnostics: vscode.Diagnostic[] = [];
-		for (let i = 0; i < 10; i++) {
-			await new Promise(resolve => setTimeout(resolve, 100));
+		for (let i = 0; i < MAX_DIAGNOSTIC_RETRIES; i++) {
+			await new Promise(resolve => setTimeout(resolve, RETRY_INTERVAL));
 			const diagnostics = vscode.languages.getDiagnostics(doc.uri);
 			snippetDiagnostics = diagnostics.filter(d => d.source === 'mkdocs-snippet-lens');
 			if (snippetDiagnostics.length > 0) {
@@ -34,7 +47,10 @@ suite('DiagnosticManager Integration Tests', () => {
 		assert.strictEqual(snippetDiagnostics[0].severity, vscode.DiagnosticSeverity.Error);
 	});
 
-	test('should create multiple diagnostics for multiple missing files', async () => {
+	test('should create multiple diagnostics for multiple missing files', async function() {
+		// Increase timeout for slower CI environments (especially macOS)
+		this.timeout(CI_TEST_TIMEOUT);
+
 		const content = `--8<-- "missing-file-1.txt"
 --8<-- "missing-file-2.txt"`;
 		const doc = await vscode.workspace.openTextDocument({
@@ -45,10 +61,13 @@ suite('DiagnosticManager Integration Tests', () => {
 		// Open the document in an editor to trigger diagnostics
 		await vscode.window.showTextDocument(doc);
 
+		// Give the editor a moment to fully activate
+		await new Promise(resolve => setTimeout(resolve, EDITOR_ACTIVATION_DELAY));
+
 		// Wait for diagnostics to be processed with retry logic
 		let snippetDiagnostics: vscode.Diagnostic[] = [];
-		for (let i = 0; i < 10; i++) {
-			await new Promise(resolve => setTimeout(resolve, 100));
+		for (let i = 0; i < MAX_DIAGNOSTIC_RETRIES; i++) {
+			await new Promise(resolve => setTimeout(resolve, RETRY_INTERVAL));
 			const diagnostics = vscode.languages.getDiagnostics(doc.uri);
 			snippetDiagnostics = diagnostics.filter(d => d.source === 'mkdocs-snippet-lens');
 			if (snippetDiagnostics.length === 2) {
@@ -61,7 +80,10 @@ suite('DiagnosticManager Integration Tests', () => {
 		assert.ok(snippetDiagnostics[1].message.includes('missing-file-2.txt'));
 	});
 
-	test('should ignore non-markdown documents', async () => {
+	test('should ignore non-markdown documents', async function() {
+		// Increase timeout for slower CI environments (especially macOS)
+		this.timeout(CI_TEST_TIMEOUT);
+
 		const content = '--8<-- "missing.txt"';
 		const doc = await vscode.workspace.openTextDocument({
 			content,
@@ -72,7 +94,7 @@ suite('DiagnosticManager Integration Tests', () => {
 		await vscode.window.showTextDocument(doc);
 
 		// Wait to ensure diagnostics would have been processed if they were going to be
-		await new Promise(resolve => setTimeout(resolve, 300));
+		await new Promise(resolve => setTimeout(resolve, NEGATIVE_TEST_WAIT));
 
 		const diagnostics = vscode.languages.getDiagnostics(doc.uri);
 		const snippetDiagnostics = diagnostics.filter(d => d.source === 'mkdocs-snippet-lens');


### PR DESCRIPTION
## Problem

The DiagnosticManager integration tests were timing out on macOS CI runners with the default 2000ms timeout.

## Root Cause

The tests trigger diagnostics by opening documents in the editor, which involves async operations that can take longer on macOS:
1. Document opening
2. Editor activation
3. Event handler triggering (`onDidChangeActiveTextEditor`)
4. Diagnostic processing

The original implementation only waited up to 1 second (10 × 100ms) for diagnostics to appear, which wasn't sufficient on slower CI environments.

## Solution

Made the tests more robust for slower CI environments:

- **Increased test timeout**: From 2000ms (default) to 5000ms
- **Added initial delay**: 200ms after `showTextDocument()` to allow editor activation
- **Increased retry attempts**: From 10 to 20 iterations (1s → 3s max wait)
- **Increased retry interval**: From 100ms to 150ms per check
- **Extended plaintext test wait**: From 300ms to 500ms
- **Extracted timing constants**: All timing values are now named constants for better maintainability

## Code Quality

Extracted hardcoded magic numbers as named constants at the suite level:
- `CI_TEST_TIMEOUT = 5000`
- `EDITOR_ACTIVATION_DELAY = 200`
- `MAX_DIAGNOSTIC_RETRIES = 20`
- `RETRY_INTERVAL = 150`
- `NEGATIVE_TEST_WAIT = 500`

This makes the purpose of each value clear and ensures consistency if values need adjustment.

## Testing

All three integration tests updated:
- `should create diagnostics for missing files`
- `should create multiple diagnostics for multiple missing files`
- `should ignore non-markdown documents`