### PR TITLE
docs: update changelog policy in copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -219,7 +219,7 @@ Access via `vscode.workspace.getConfiguration('mkdocsSnippetLens')`.
 
 ## Documentation
 
-- Update CHANGELOG.md for all user-visible changes
+- DO NOT UPDATE CHANGELOG.md since it is generated
 - Keep README.md examples up-to-date
 - Document limitations in README known issues section
 - Use inline comments for complex logic


### PR DESCRIPTION
## Description

Updates the copilot instructions to reflect that CHANGELOG.md is now generated automatically and should not be manually updated by Copilot.

## Changes

- Updated `.github/copilot-instructions.md` to change the documentation policy from "Update CHANGELOG.md for all user-visible changes" to "DO NOT UPDATE CHANGELOG.md since it is generated"

## Motivation

The project now uses automated changelog generation, so manual updates to CHANGELOG.md should be avoided to prevent conflicts and maintain consistency.