### PR TITLE
docs: add PR creation guidelines to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -273,3 +273,14 @@ Follow Conventional Commits:
 - `chore:` - Build/tooling changes
 
 Use commitlint for validation (already configured in project).
+
+## Pull Request Creation
+
+**Always create PRs from a new branch based on the tip of origin/main:**
+
+1. Ensure local main is up-to-date: `git fetch origin main`
+2. Create a new branch from origin/main: `git checkout -b feature/your-branch-name origin/main`
+3. Make your changes and commit following conventional commits
+4. Push the branch and create the PR
+
+Never create PRs from other branches or directly from main.


### PR DESCRIPTION
## Summary

Adds guidelines to the Copilot instructions for creating pull requests from a new branch based on the tip of origin/main.

## Changes

- Added new "Pull Request Creation" section to `.github/copilot-instructions.md`
- Specifies workflow to ensure PRs are always created from origin/main
- Includes steps: fetch, create branch from origin/main, commit, and push
- Clarifies to never create PRs from other branches or directly from main

## Motivation

Ensures consistent PR workflow and helps avoid issues with outdated branches or conflicts when creating pull requests.