### PR TITLE
docs: document fallback behavior for invalid multi-range patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ This extension contributes the following settings:
 
 ## Known Issues
 
+### Parser Fallback Behavior
+
+When an invalid multi-range pattern is encountered (e.g., `--8<-- "file.md:1:3,invalid"`
+where one of the ranges is malformed), the parser falls back to treating the entire
+reference as a section reference. This means the example above would be parsed as
+`path="file.md:1"` with `section="3,invalid"`, which may not match your intent.
+
+To avoid this, ensure multi-range patterns use the correct format with all ranges as
+numeric pairs: `--8<-- "file.md:1:3,5:7"`
+
 See the
 [issue tracker](https://github.com/main-branch/mkdocs-snippet-lens/issues) for known
 issues.

--- a/src/snippetDetector.ts
+++ b/src/snippetDetector.ts
@@ -31,6 +31,12 @@ export class SnippetDetector {
 			const ref = match[1];
 
 			// Try to match multiple line ranges pattern (numeric:numeric,numeric:numeric...)
+			// Note: If this validation fails, the code will fall through to the section pattern
+			// matcher below. This means invalid multi-range patterns like "file.md:1:3,invalid"
+		// will be parsed as a section reference instead of a multi-range reference (path="file.md:1", section="3,invalid").
+			// This fallback behavior can result in unexpected parsing for malformed multi-range
+			// input where the user likely intended a multi-range but made a typo. However, it
+			// allows the extension to continue functioning rather than failing entirely.
 			const multiRangeMatch = ref.match(/^(.*?):(.+)$/);
 			if (multiRangeMatch && multiRangeMatch[2].includes(',')) {
 				const path = multiRangeMatch[1];
@@ -38,12 +44,14 @@ export class SnippetDetector {
 				const rangeParts = rangesStr.split(',');
 				const ranges: Array<{ start: number; end: number }> = [];
 
+				// Validate each range part is in numeric:numeric format
 				let allRangesValid = true;
 				for (const part of rangeParts) {
 					const rangeMatch = part.match(/^(\d+):(\d+)$/);
 					if (rangeMatch) {
 						ranges.push({ start: parseInt(rangeMatch[1], 10), end: parseInt(rangeMatch[2], 10) });
 					} else {
+						// Invalid range part found - will fall back to section pattern below
 						allRangesValid = false;
 						break;
 					}
@@ -53,6 +61,7 @@ export class SnippetDetector {
 					snippets.push({ path, lineRanges: ranges });
 					continue;
 				}
+				// If validation failed, fall through to try section pattern next
 			}
 
 			// Try to match line range pattern (numeric:numeric)

--- a/src/test/unit/snippetDetector.test.ts
+++ b/src/test/unit/snippetDetector.test.ts
@@ -81,7 +81,7 @@ describe('SnippetDetector', () => {
 			]);
 		});
 
-		it('should treat invalid multi-range as section name', () => {
+		it('should fall back to section pattern when multi-range validation fails', () => {
 			const detector = new SnippetDetector();
 			const text = '--8<-- "file.md:1:3,invalid"';
 			const result = detector.detect(text);


### PR DESCRIPTION
## Summary

This PR implements issue #33 by adding comprehensive documentation for the fallback behavior when invalid multi-range patterns are encountered in snippet references.

## Changes

- **Renamed test** to accurately describe behavior: "should fall back to section pattern when multi-range validation fails"
- **Added code comments** in `snippetDetector.ts` explaining the fallback logic
- **Documented the limitation** that invalid patterns like `"file.md:1:3,invalid"` fall back to section pattern matching, resulting in `path="file.md:1"`, `section="3,invalid"`

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- ✅ All 84 unit tests passing
- ✅ 100% code coverage maintained
- ✅ No functional changes

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated appropriately
- [x] No breaking changes

Fixes #33