### PR TITLE
feat: add error handling for ambiguous/malformed snippet patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,20 @@ This extension contributes the following settings:
 
 ## Known Issues
 
-### Parser Fallback Behavior
+### Ambiguous Multi-Range Pattern Detection
 
-When an invalid multi-range pattern is encountered (e.g., `--8<-- "file.md:1:3,invalid"`
-where one of the ranges is malformed), the parser falls back to treating the entire
-reference as a section reference. This means the example above would be parsed as
-`path="file.md:1"` with `section="3,invalid"`, which may not match your intent.
+When a multi-range pattern is malformed (e.g., `--8<-- "file.md:1:3,invalid"` where one
+of the ranges contains non-numeric parts or is incomplete like `"file.md:1:,5:7"`), the
+extension will:
 
-To avoid this, ensure multi-range patterns use the correct format with all ranges as
-numeric pairs: `--8<-- "file.md:1:3,5:7"`
+1. Still parse the reference (falling back to treating it as a section reference)
+2. Display a diagnostic warning to alert you about the ambiguous pattern
+3. Show the specific issue in the error message (e.g., "Multi-range pattern contains
+   non-numeric part: 'invalid'")
+
+This helps catch typos in multi-range patterns while allowing the extension to continue
+functioning. To avoid warnings, ensure multi-range patterns use the correct format with
+all ranges as numeric pairs: `--8<-- "file.md:1:3,5:7"`
 
 See the
 [issue tracker](https://github.com/main-branch/mkdocs-snippet-lens/issues) for known

--- a/src/diagnosticCreator.ts
+++ b/src/diagnosticCreator.ts
@@ -22,6 +22,16 @@ export function createDiagnosticInfos(
   const diagnostics: DiagnosticInfo[] = [];
 
   for (const location of locations) {
+    // Check for ambiguous patterns first
+    if (location.snippet.isAmbiguous && location.snippet.ambiguousReason) {
+      diagnostics.push({
+        message: location.snippet.ambiguousReason,
+        startOffset: location.startOffset,
+        endOffset: location.endOffset,
+      });
+    }
+
+    // Check for missing files
     const resolvedPath = resolvePath(location.snippet.path);
     if (!resolvedPath) {
       diagnostics.push({


### PR DESCRIPTION
## Problem

Issue #34 identified that malformed multi-range patterns were silently falling back to section pattern matching, which could produce unexpected results without user feedback. For example:

```markdown
--8<-- "file.md:1:3,invalid"
```

Would be parsed as `path="file.md"` with `section="1:3,invalid"` instead of alerting the user about the malformed pattern.

## Solution

This PR implements explicit handling for ambiguous or malformed snippet patterns:

### Changes Made

1. **Enhanced SnippetInfo Interface**
   - Added `isAmbiguous?: boolean` flag to mark malformed patterns
   - Added `ambiguousReason?: string` to provide detailed error messages

2. **Improved Pattern Detection Logic**
   - Enhanced multi-range validation to detect malformed ranges
   - Distinguishes between non-numeric parts (e.g., "invalid") and malformed numeric ranges (e.g., "5:")
   - Sets ambiguous flag when patterns look like multi-range but are malformed
   - Provides helpful error messages for different types of malformed patterns

3. **Added Diagnostic Warnings**
   - Extended `createDiagnosticInfos` to check for ambiguous patterns
   - Shows diagnostic warnings in VS Code when malformed patterns are detected
   - Works alongside existing file-not-found diagnostics

4. **Updated Documentation**
   - Replaced "Parser Fallback Behavior" with "Ambiguous Multi-Range Pattern Detection"
   - Explains the new warning system with examples
   - Provides guidance on correct pattern format

### Example Scenarios Handled

- `"file.md:1:3,invalid"` - Multi-range with non-numeric part → Warning: "Multi-range pattern contains non-numeric part: 'invalid'"
- `"file.md:1:,5:7"` - Multi-range with empty range → Warning: "Multi-range pattern contains malformed range: '1:'"
- `"file.md:1:3,5:"` - Multi-range with incomplete range → Warning: "Multi-range pattern contains malformed range: '5:'"

### Test Coverage

- ✅ Added 6 new unit tests for ambiguous pattern detection
- ✅ Added 3 new diagnostic tests for ambiguous warnings
- ✅ All 93 unit tests passing
- ✅ All 9 integration tests passing
- ✅ 100% code coverage maintained

### Backwards Compatibility

- ✅ No breaking changes to existing functionality
- ✅ Valid patterns continue to work as expected
- ✅ Only adds warnings for malformed patterns, doesn't break existing behavior

## Testing

Ran full test suite:

```bash
npm run test:all
```

All tests pass with 100% coverage.

## Related Issues

Closes #34