### PR TITLE
fix: allow feat commits to bump minor version in pre-1.0.0 releases

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,6 @@
     ".": {
       "release-type": "node",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "pull-request-title-pattern": "chore: release v${version}",


### PR DESCRIPTION
## Problem

Release-please was configured with `bump-patch-for-minor-pre-major: true`, which caused `feat:` commits to only bump the patch version (0.1.1 → 0.1.2) instead of the minor version (0.1.1 → 0.2.0) for pre-1.0.0 releases.

This made it impossible to distinguish between feature releases and patch releases in version numbers.

## Solution

Remove the `bump-patch-for-minor-pre-major` setting from `.release-please-config.json`.

## Impact

After this change, version bumping will work as follows for versions < 1.0.0:

| Commit Type | Version Bump | Example |
|-------------|--------------|---------|
| `feat:` | minor | 0.1.1 → 0.2.0 |
| `BREAKING CHANGE:` | minor | 0.1.1 → 0.2.0 |
| `fix:` | patch | 0.1.1 → 0.1.2 |

For versions ≥ 1.0.0, standard semantic versioning applies (BREAKING CHANGE bumps major).

## Next Steps

Once this PR is merged, the next release-please run should correctly suggest version 0.2.0 instead of 0.1.2 for the pending release that includes multiple feature commits.