### PR TITLE
build(dependencies): update dependencies for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,7 +92,7 @@ jobs:
         run: npm run package
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: extension-build
           path: dist/

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Secure runner
-        uses: step-security/harden-runner@v2.11.1
+        uses: step-security/harden-runner@v2
         with:
           disable-sudo: true
           egress-policy: block
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Define release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Secure runner
-        uses: step-security/harden-runner@v2.11.1
+        uses: step-security/harden-runner@v2
         with:
           disable-sudo: true
           egress-policy: block


### PR DESCRIPTION
Updates GitHub Actions to their latest floating major versions.

## Changes

| Action | Old | New | Latest |
|--------|-----|-----|--------|
| `actions/upload-artifact` | `@v5` | `@v7` | v7.0.1 |
| `googleapis/release-please-action` | `@v4` | `@v5` | v5.0.0 |
| `step-security/harden-runner` | `@v2.11.1` | `@v2` | v2.19.0 |

No changes needed for:
- `actions/checkout@v6` — latest is still v6 (v6.0.2)
- `actions/setup-node@v6` — latest is still v6 (v6.4.0)
- `wagoid/commitlint-github-action@v6` — latest is still v6 (v6.2.1)